### PR TITLE
Add a mode in with, new replays in osu! folder are automatically loaded

### DIFF
--- a/OsuMissAnalyzer.UI/App.xaml.cs
+++ b/OsuMissAnalyzer.UI/App.xaml.cs
@@ -33,6 +33,13 @@ namespace OsuMissAnalyzer.UI
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 Window = desktop.MainWindow = new MissWindow();
+                if (ReplayLoader.Options.WatchDogMode && (!ReplayLoader.Options.Settings.ContainsKey("osudir") || string.IsNullOrEmpty(ReplayLoader.Options.Settings["osudir"])))
+                {
+                    await ShowMessageBox("OsuDir is required when WatchDogMode is enabled.");
+                    Window.Close();
+                    return;
+                }
+
                 await Load(ReplayLoader);
                 if (ReplayLoader.Options.WatchDogMode)
                 {

--- a/OsuMissAnalyzer.UI/Options.cs
+++ b/OsuMissAnalyzer.UI/Options.cs
@@ -16,6 +16,7 @@ namespace OsuMissAnalyzer.UI
 		public ScoresDb ScoresDb;
 		public bool OsuDirAccessible { get; private set; }
         public string SongsFolder => Settings.GetValueOrDefault("songsdir", Settings.ContainsKey("osudir") ? Path.Combine(Settings["osudir"], "Songs") : null);
+        public bool WatchDogMode => "true" == Settings.GetValueOrDefault("watchdogmode", Settings.ContainsKey("watchdogmode") ? Settings["watchdogmode"].ToLowerInvariant() : "false");
 		public Options(string file, Dictionary<string, string> optList)
 		{
 			OsuDirAccessible = false;

--- a/OsuMissAnalyzer.UI/Program.cs
+++ b/OsuMissAnalyzer.UI/Program.cs
@@ -29,6 +29,7 @@ namespace OsuMissAnalyzer.UI
                 { "o|osudir=", "Set osu! directory", o => optList["osudir"] = o},
                 { "c|config=", "Set options.cfg", f => optionsFile = f},
                 { "s|songsdir=", "Set songs directory", s => optList["songsdir"] = s},
+                { "w|watchdogmode=", "watch and automatically load newest replays, requires osudir to be set", s => optList["watchdogmode"] = s},
                 { "d|daemon", "Run without dialogs", d => headless = d != null},
                 { "h|help", "Displays help", h => help = h != null},
                 { "m|miss=", "Export miss #", (int m) => getMiss = m}

--- a/OsuMissAnalyzer.UI/Program.cs
+++ b/OsuMissAnalyzer.UI/Program.cs
@@ -49,6 +49,7 @@ namespace OsuMissAnalyzer.UI
                 Debug.Print("- Available settings : SongsDir | Value = Specify osu!'s songs dir.");
                 Debug.Print("-                       APIKey  | Value = Your osu! API key (https://osu.ppy.sh/api/");
                 Debug.Print("-                       OsuDir  | Value = Your osu! directory");
+                Debug.Print("-                 WatchDogMode  | Value = true or false");
             }
             if (help)
             {

--- a/OsuMissAnalyzer.UI/ViewModels/ReplayOptionBoxViewModel.cs
+++ b/OsuMissAnalyzer.UI/ViewModels/ReplayOptionBoxViewModel.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace OsuMissAnalyzer.UI.ViewModels
 {
-    public enum ReplayFind { RECENT, BEATMAP, MANUAL }
+    public enum ReplayFind { WATCHDOG, RECENT, BEATMAP, MANUAL }
     public class ReplayOptionBoxViewModel : ViewModelBase
     {
         private ReplayFind? result;

--- a/OsuMissAnalyzer.UI/options.cfg
+++ b/OsuMissAnalyzer.UI/options.cfg
@@ -1,2 +1,3 @@
 ﻿OsuDir=
 SongsDir=
+WatchDogMode=false

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To add these to options.cfg, add a new line formatted `<Setting Name>=<Value>`
 |OsuDir|Specify the osu! directory. Make sure that osu!.db is in here. If the program takes a while to start, please add this option.|
 |SongsDir|Specify osu!'s songs dir. Only necessary if it isn't OsuDir/Songs.|
 |APIKey|osu! API key|
-|WatchDogMode|Enable watch dog mode, in with newest replays in OsuDir are loaded as they appear. OsuDir is required and SongsDir is recommended for best experience.|
+|WatchDogMode|Enable watch dog mode, in with newest replays in OsuDir are loaded as they appear.|
 
 ## Alternate Usage
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To add these to options.cfg, add a new line formatted `<Setting Name>=<Value>`
 |OsuDir|Specify the osu! directory. Make sure that osu!.db is in here. If the program takes a while to start, please add this option.|
 |SongsDir|Specify osu!'s songs dir. Only necessary if it isn't OsuDir/Songs.|
 |APIKey|osu! API key|
-|WatchDogMode|Enable watch dog mode, in with newest replays in OsuDir are loaded as they appear.|
+|WatchDogMode|Enable watch dog mode, in which newest replays in OsuDir are loaded as they appear.|
 
 ## Alternate Usage
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To add these to options.cfg, add a new line formatted `<Setting Name>=<Value>`
 |OsuDir|Specify the osu! directory. Make sure that osu!.db is in here. If the program takes a while to start, please add this option.|
 |SongsDir|Specify osu!'s songs dir. Only necessary if it isn't OsuDir/Songs.|
 |APIKey|osu! API key|
+|WatchDogMode|Enable watch dog mode, in with newest replays in OsuDir are loaded as they appear. OsuDir is required and SongsDir is recommended for best experience.|
 
 ## Alternate Usage
 


### PR DESCRIPTION
Enabling this `WatchDogMode` makes missAnalyzer load newest(by file edit date) replay in either user `Replays` folder or `Data/r` folder at startup, while at the same time monitoring these folders for new replays.